### PR TITLE
Handle --version/-v flags

### DIFF
--- a/lib/_inspect.js
+++ b/lib/_inspect.js
@@ -24,17 +24,19 @@ const { spawn } = require('child_process');
 const { EventEmitter } = require('events');
 const util = require('util');
 
-const [ InspectClient, createRepl ] =
+const [ InspectClient, createRepl, cliVersion ] =
   (typeof __dirname !== 'undefined') ?
   // This copy of node-inspect is on-disk, relative paths make sense.
   [
     require('./internal/inspect_client'),
-    require('./internal/inspect_repl')
+    require('./internal/inspect_repl'),
+    require('../package.json').version
   ] :
   // This copy of node-inspect is built into the node executable.
   [
     require('node-inspect/lib/internal/inspect_client'),
-    require('node-inspect/lib/internal/inspect_repl')
+    require('node-inspect/lib/internal/inspect_repl'),
+    null
   ];
 
 const debuglog = util.debuglog('inspect');
@@ -230,6 +232,10 @@ function parseArgv([target, ...args]) {
   let script = target;
   let scriptArgs = args;
 
+  if (target === '--version' || target === '-v') {
+    return { version: true };
+  }
+
   const hostMatch = target.match(/^([^:]+):(\d+)$/);
   const portMatch = target.match(/^--port=(\d+)$/);
   if (hostMatch) {
@@ -264,6 +270,12 @@ function startInspect(argv = process.argv.slice(2),
   }
 
   const options = parseArgv(argv);
+  if (options.version) {
+    console.log(cliVersion ?
+      `v${cliVersion}` : `node ${process.version} (bundled)`);
+    process.exit(0);
+  }
+
   const inspector = new NodeInspector(options, stdin, stdout);
 
   stdin.resume();

--- a/test/cli/dash-version.test.js
+++ b/test/cli/dash-version.test.js
@@ -1,0 +1,27 @@
+'use strict';
+const { test } = require('tap');
+
+const PKG = require('../../package.json');
+
+const startCLI = require('./start-cli');
+
+const isEmbedded = process.env.USE_EMBEDDED_NODE_INSPECT === '1';
+
+test('retrieve CLI version', (t) => {
+  const cli = startCLI(['--version']);
+
+  function onFatal(error) {
+    cli.quit();
+    throw error;
+  }
+
+  return cli.waitForExit()
+    .then(() => {
+      if (isEmbedded) {
+        t.include(cli.output, '(bundled)');
+      } else {
+        t.equal(cli.output, `v${PKG.version}\n`);
+      }
+    })
+    .then(null, onFatal);
+});

--- a/test/cli/start-cli.js
+++ b/test/cli/start-cli.js
@@ -42,6 +42,30 @@ function startCLI(args) {
       return output;
     },
 
+    waitForExit(timeout = 2000) {
+      return new Promise((resolve, reject) => {
+        function onChildExit() {
+          tearDown(); // eslint-disable-line no-use-before-define
+          resolve();
+        }
+
+        const timer = setTimeout(() => {
+          tearDown(); // eslint-disable-line no-use-before-define
+          reject(new Error([
+            `Timeout (${timeout}) while waiting for exit`,
+            `found: ${this.output}`,
+          ].join('; ')));
+        }, timeout);
+
+        function tearDown() {
+          clearTimeout(timer);
+          child.removeListener('exit', onChildExit);
+        }
+
+        child.on('exit', onChildExit);
+      });
+    },
+
     waitFor(pattern, timeout = 2000) {
       function checkPattern(str) {
         if (Array.isArray(pattern)) {


### PR DESCRIPTION
The current behavior is less than helpful because it will spawn a `node --version` process that immediately exits without ever exposing the debug protocol.

##### Before

```
$ node-inspect --version
< v6.9.1
[ nothing, just hangs ]
```

##### After

```
$ node-inspect --version
v1.10.5

$ node inspect --version
node v8.0.0-pre (bundled)
```