### PR TITLE
print 'ok' after connection

### DIFF
--- a/lib/_inspect.js
+++ b/lib/_inspect.js
@@ -175,6 +175,7 @@ class NodeInspector {
         return this.client.connect()
           .then(() => {
             debuglog('connection established');
+            this.stdout.write(' ok');
           }, (error) => {
             debuglog('connect failed', error);
             // If it's failed to connect 10 times then print failed message


### PR DESCRIPTION
This change makes inspect more compatible with the old debugger. There
are some Node.js core test-cases that are expecting the 'ok' to show up
here.

I am investigating if we can make `node debug` an alias of `node inspect`.