### PR TITLE
fix: Make autocompletion in REPL work

### DIFF
--- a/lib/internal/inspect_repl.js
+++ b/lib/internal/inspect_repl.js
@@ -238,6 +238,7 @@ class ScopeSnapshot {
       const value = new RemoteObject(prop.value);
       return [prop.name, value];
     }));
+    this.completionGroup = properties.map((prop) => prop.name);
   }
 
   [util.inspect.custom](depth, opts) {
@@ -480,7 +481,9 @@ function createRepl(inspector) {
       if (!selectedFrame) {
         return Promise.reject(new Error('Requires execution to be paused'));
       }
-      return selectedFrame.loadScopes();
+      return selectedFrame.loadScopes().then((scopes) => {
+        return scopes.map((scope) => scope.completionGroup);
+      });
     }
 
     if (selectedFrame) {


### PR DESCRIPTION
There was a bug in `internal/inspect_repl.js` that caused REPL to crash
when trying to invoke autocomplete. Steps to reproduce:

* Start the debugger.
* Run `repl` command.
* Type any letter.
* Press <Tab>.
* Debugger crashes with `TypeError: elem.indexOf is not a function`.

The reason is that Node's REPL expects a completion group to be an
array of strings while node-inspect passed an instance of ScopeSnapshot.

This commit fixes it by adding completion groups for REPL as properties
of ScopeSnapshot instances and returning them when evaluating ".scope".