### PR TITLE
Remove console.error() statement

### DIFF
--- a/lib/internal/inspect_repl.js
+++ b/lib/internal/inspect_repl.js
@@ -234,7 +234,6 @@ class ScopeSnapshot {
   constructor(scope, properties) {
     Object.assign(this, scope);
     this.properties = new Map(properties.map((prop) => {
-      // console.error(prop);
       const value = new RemoteObject(prop.value);
       return [prop.name, value];
     }));


### PR DESCRIPTION
This commits removes a commented-out `console.error()` statement.