### PR TITLE
Fix test issues on AIX

### DIFF
--- a/lib/_inspect.js
+++ b/lib/_inspect.js
@@ -160,38 +160,40 @@ class NodeInspector {
       this.child.kill();
       this.child = null;
     }
+    return new Promise((resolve) => setTimeout(resolve, 2000));
   }
 
   run() {
-    this.killChild();
-    return this._runScript().then((child) => {
-      this.child = child;
+    return this.killChild().then(() => {
+      return this._runScript().then((child) => {
+        this.child = child;
 
-      let connectionAttempts = 0;
-      const attemptConnect = () => {
-        ++connectionAttempts;
-        debuglog('connection attempt #%d', connectionAttempts);
-        this.stdout.write('.');
-        return this.client.connect()
-          .then(() => {
-            debuglog('connection established');
-            this.stdout.write(' ok');
-          }, (error) => {
-            debuglog('connect failed', error);
-            // If it's failed to connect 10 times then print failed message
-            if (connectionAttempts >= 10) {
-              this.stdout.write(' failed to connect, please retry\n');
-              process.exit(1);
-            }
+        let connectionAttempts = 0;
+        const attemptConnect = () => {
+          ++connectionAttempts;
+          debuglog('connection attempt #%d', connectionAttempts);
+          this.stdout.write('.');
+          return this.client.connect()
+            .then(() => {
+              debuglog('connection established');
+              this.stdout.write(' ok');
+            }, (error) => {
+              debuglog('connect failed', error);
+              // If it's failed to connect 10 times then print failed message
+              if (connectionAttempts >= 10) {
+                this.stdout.write(' failed to connect, please retry\n');
+                process.exit(1);
+              }
 
-            return new Promise((resolve) => setTimeout(resolve, 500))
-              .then(attemptConnect);
-          });
-      };
+              return new Promise((resolve) => setTimeout(resolve, 500))
+                .then(attemptConnect);
+            });
+        };
 
-      const { host, port } = this.options;
-      this.print(`connecting to ${host}:${port} ..`, true);
-      return attemptConnect();
+        const { host, port } = this.options;
+        this.print(`connecting to ${host}:${port} ..`, true);
+        return attemptConnect();
+      });
     });
   }
 

--- a/lib/internal/inspect_repl.js
+++ b/lib/internal/inspect_repl.js
@@ -752,6 +752,7 @@ function createRepl(inspector) {
     if (!newBreakpoints.length) return;
     Promise.all(newBreakpoints).then((results) => {
       print(`${results.length} breakpoints restored.`);
+      repl.displayPrompt();
     });
   }
 

--- a/test/cli/exceptions.test.js
+++ b/test/cli/exceptions.test.js
@@ -5,6 +5,11 @@ const { test } = require('tap');
 
 const startCLI = require('./start-cli');
 
+var brkLine = 1;
+if (process.platform == 'aix') {
+  brkLine = 2;
+}
+
 test('break on (uncaught) exceptions', (t) => {
   const script = Path.join('examples', 'exceptions.js');
   const cli = startCLI([script]);
@@ -17,7 +22,7 @@ test('break on (uncaught) exceptions', (t) => {
   return cli.waitFor(/break/)
     .then(() => cli.waitForPrompt())
     .then(() => {
-      t.match(cli.output, `break in ${script}:1`);
+      t.match(cli.output, `break in ${script}:${brkLine}`);
     })
     // making sure it will die by default:
     .then(() => cli.command('c'))
@@ -26,7 +31,7 @@ test('break on (uncaught) exceptions', (t) => {
     // Next run: With `breakOnException` it pauses in both places
     .then(() => cli.stepCommand('r'))
     .then(() => {
-      t.match(cli.output, `break in ${script}:1`);
+      t.match(cli.output, `break in ${script}:${brkLine}`);
     })
     .then(() => cli.command('breakOnException'))
     .then(() => cli.stepCommand('c'))
@@ -42,7 +47,7 @@ test('break on (uncaught) exceptions', (t) => {
     .then(() => cli.command('breakOnUncaught'))
     .then(() => cli.stepCommand('r')) // also, the setting survives the restart
     .then(() => {
-      t.match(cli.output, `break in ${script}:1`);
+      t.match(cli.output, `break in ${script}:${brkLine}`);
     })
     .then(() => cli.stepCommand('c'))
     .then(() => {
@@ -53,7 +58,7 @@ test('break on (uncaught) exceptions', (t) => {
     .then(() => cli.command('breakOnNone'))
     .then(() => cli.stepCommand('r'))
     .then(() => {
-      t.match(cli.output, `break in ${script}:1`);
+      t.match(cli.output, `break in ${script}:${brkLine}`);
     })
     .then(() => cli.command('c'))
     .then(() => cli.waitFor(/disconnect/))

--- a/test/cli/exceptions.test.js
+++ b/test/cli/exceptions.test.js
@@ -5,11 +5,6 @@ const { test } = require('tap');
 
 const startCLI = require('./start-cli');
 
-var brkLine = 1;
-if (process.platform == 'aix') {
-  brkLine = 2;
-}
-
 test('break on (uncaught) exceptions', (t) => {
   const script = Path.join('examples', 'exceptions.js');
   const cli = startCLI([script]);
@@ -22,7 +17,7 @@ test('break on (uncaught) exceptions', (t) => {
   return cli.waitFor(/break/)
     .then(() => cli.waitForPrompt())
     .then(() => {
-      t.match(cli.output, `break in ${script}:${brkLine}`);
+      t.match(cli.output, `break in ${script}:1`);
     })
     // making sure it will die by default:
     .then(() => cli.command('c'))
@@ -31,7 +26,7 @@ test('break on (uncaught) exceptions', (t) => {
     // Next run: With `breakOnException` it pauses in both places
     .then(() => cli.stepCommand('r'))
     .then(() => {
-      t.match(cli.output, `break in ${script}:${brkLine}`);
+      t.match(cli.output, `break in ${script}:1`);
     })
     .then(() => cli.command('breakOnException'))
     .then(() => cli.stepCommand('c'))
@@ -47,7 +42,7 @@ test('break on (uncaught) exceptions', (t) => {
     .then(() => cli.command('breakOnUncaught'))
     .then(() => cli.stepCommand('r')) // also, the setting survives the restart
     .then(() => {
-      t.match(cli.output, `break in ${script}:${brkLine}`);
+      t.match(cli.output, `break in ${script}:1`);
     })
     .then(() => cli.stepCommand('c'))
     .then(() => {
@@ -58,7 +53,7 @@ test('break on (uncaught) exceptions', (t) => {
     .then(() => cli.command('breakOnNone'))
     .then(() => cli.stepCommand('r'))
     .then(() => {
-      t.match(cli.output, `break in ${script}:${brkLine}`);
+      t.match(cli.output, `break in ${script}:1`);
     })
     .then(() => cli.command('c'))
     .then(() => cli.waitFor(/disconnect/))

--- a/test/cli/start-cli.js
+++ b/test/cli/start-cli.js
@@ -42,7 +42,7 @@ function startCLI(args) {
       return output;
     },
 
-    waitFor(pattern, timeout = 2000) {
+    waitFor(pattern, timeout = 5000) {
       function checkPattern(str) {
         if (Array.isArray(pattern)) {
           return pattern.every((p) => p.test(str));
@@ -84,7 +84,7 @@ function startCLI(args) {
       });
     },
 
-    waitForPrompt(timeout = 2000) {
+    waitForPrompt(timeout = 5000) {
       return this.waitFor(/>\s+$/, timeout);
     },
 


### PR DESCRIPTION
This is a fix to support issue #24.  I found that looking at AIX, there's an issue when using the restart command in the debugger.  AIX seems unable to shutdown it's process quickly enough and still has the socket when the new debugging attempts to bind to port 9229.

In order to fix this, I added a small delay so when the child process is killed it has time to shut down it's socket before restarting.

The other issue that seems unique to AIX involves the issue, once again, of restarting after adding some breakpoints (the `preserve-breaks.test.js` test)  There seems to be an issue here in the ordering of the output from the debugger.  Sometimes we see the "`breakpoints restored`" message before the source listing, and other times it would come afterwards.  The side effect of this message appearing at the end like this, is that it would overwrite the "`debug>`" prompt and then the test would fail.

This might need more investigation to see if the ordering of the text can be fixed, but in order to fix the ci run, I've made a change to explicitly put the "`debug>`" prompt out after the "`breakpoints restored`" message is output.

There's one further problem in AIX I observed in which the initial breakpoint in the `exceptions.test.js` test looks incorrect, but I will open a new issue to track this.