### PR TITLE
Update test suite to pass on latest nightly

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "pretest": "eslint --rulesdir=tools/eslint-rules lib test",
-    "test": "tap \"test/**/*.test.js\"",
+    "test": "tap test",
     "posttest": "nlm verify"
   },
   "nlm": {

--- a/test/cli/backtrace.test.js
+++ b/test/cli/backtrace.test.js
@@ -14,7 +14,7 @@ test('display and navigate backtrace', (t) => {
     throw error;
   }
 
-  return cli.waitFor(/break/)
+  return cli.waitForInitialBreak()
     .then(() => cli.waitForPrompt())
     .then(() => cli.stepCommand('c'))
     .then(() => cli.command('bt'))

--- a/test/cli/break.test.js
+++ b/test/cli/break.test.js
@@ -14,12 +14,12 @@ test('stepping through breakpoints', (t) => {
     throw error;
   }
 
-  return cli.waitFor(/break/)
+  return cli.waitForInitialBreak()
     .then(() => cli.waitForPrompt())
     .then(() => {
       t.match(
         cli.output,
-        `break in ${script}:1`,
+        ` in ${script}:1`,
         'pauses in the first line of the script');
       t.match(
         cli.output,
@@ -30,7 +30,7 @@ test('stepping through breakpoints', (t) => {
     .then(() => {
       t.match(
         cli.output,
-        `break in ${script}:2`,
+        ` in ${script}:2`,
         'pauses in next line of the script');
       t.match(
         cli.output,
@@ -41,7 +41,7 @@ test('stepping through breakpoints', (t) => {
     .then(() => {
       t.match(
         cli.output,
-        `break in ${script}:3`,
+        ` in ${script}:3`,
         'pauses in next line of the script');
       t.match(
         cli.output,
@@ -52,7 +52,7 @@ test('stepping through breakpoints', (t) => {
     .then(() => {
       t.match(
         cli.output,
-        `break in ${script}:10`,
+        ` in ${script}:10`,
         'pauses on the next breakpoint');
       t.match(
         cli.output,
@@ -94,21 +94,21 @@ test('stepping through breakpoints', (t) => {
     .then(() => {
       t.match(
         cli.output,
-        'break in timers.js',
+        ' in timers.js',
         'entered timers.js');
     })
     .then(() => cli.stepCommand('cont'))
     .then(() => {
       t.match(
         cli.output,
-        `break in ${script}:16`,
+        ` in ${script}:16`,
         'found breakpoint we set above w/ line number only');
     })
     .then(() => cli.stepCommand('cont'))
     .then(() => {
       t.match(
         cli.output,
-        `break in ${script}:6`,
+        ` in ${script}:6`,
         'found breakpoint we set above w/ line number & script');
     })
     .then(() => cli.stepCommand(''))
@@ -132,7 +132,7 @@ test('sb before loading file', (t) => {
     throw error;
   }
 
-  return cli.waitFor(/break/)
+  return cli.waitForInitialBreak()
     .then(() => cli.waitForPrompt())
     .then(() => cli.command('sb("other.js", 3)'))
     .then(() => {
@@ -145,7 +145,7 @@ test('sb before loading file', (t) => {
     .then(() => {
       t.match(
         cli.output,
-        `break in ${otherScript}:3`,
+        ` in ${otherScript}:3`,
         'found breakpoint in file that was not loaded yet');
     })
     .then(() => cli.quit())
@@ -161,7 +161,7 @@ test('clearBreakpoint', (t) => {
     throw error;
   }
 
-  return cli.waitFor(/break/)
+  return cli.waitForInitialBreak()
     .then(() => cli.waitForPrompt())
     .then(() => cli.command('sb("break.js", 3)'))
     .then(() => cli.command('sb("break.js", 9)'))
@@ -187,7 +187,7 @@ test('clearBreakpoint', (t) => {
     .then(() => {
       t.match(
         cli.output,
-        `break in ${script}:9`,
+        ` in ${script}:9`,
         'hits the 2nd breakpoint because the 1st was cleared');
     })
     .then(() => cli.quit())

--- a/test/cli/break.test.js
+++ b/test/cli/break.test.js
@@ -19,7 +19,7 @@ test('stepping through breakpoints', (t) => {
     .then(() => {
       t.match(
         cli.output,
-        ` in ${script}:1`,
+        `break in ${script}:1`,
         'pauses in the first line of the script');
       t.match(
         cli.output,
@@ -30,7 +30,7 @@ test('stepping through breakpoints', (t) => {
     .then(() => {
       t.match(
         cli.output,
-        ` in ${script}:2`,
+        `break in ${script}:2`,
         'pauses in next line of the script');
       t.match(
         cli.output,
@@ -41,7 +41,7 @@ test('stepping through breakpoints', (t) => {
     .then(() => {
       t.match(
         cli.output,
-        ` in ${script}:3`,
+        `break in ${script}:3`,
         'pauses in next line of the script');
       t.match(
         cli.output,
@@ -52,7 +52,7 @@ test('stepping through breakpoints', (t) => {
     .then(() => {
       t.match(
         cli.output,
-        ` in ${script}:10`,
+        `break in ${script}:10`,
         'pauses on the next breakpoint');
       t.match(
         cli.output,
@@ -94,21 +94,21 @@ test('stepping through breakpoints', (t) => {
     .then(() => {
       t.match(
         cli.output,
-        ' in timers.js',
+        'break in timers.js',
         'entered timers.js');
     })
     .then(() => cli.stepCommand('cont'))
     .then(() => {
       t.match(
         cli.output,
-        ` in ${script}:16`,
+        `break in ${script}:16`,
         'found breakpoint we set above w/ line number only');
     })
     .then(() => cli.stepCommand('cont'))
     .then(() => {
       t.match(
         cli.output,
-        ` in ${script}:6`,
+        `break in ${script}:6`,
         'found breakpoint we set above w/ line number & script');
     })
     .then(() => cli.stepCommand(''))
@@ -145,7 +145,7 @@ test('sb before loading file', (t) => {
     .then(() => {
       t.match(
         cli.output,
-        ` in ${otherScript}:3`,
+        `break in ${otherScript}:3`,
         'found breakpoint in file that was not loaded yet');
     })
     .then(() => cli.quit())
@@ -187,7 +187,7 @@ test('clearBreakpoint', (t) => {
     .then(() => {
       t.match(
         cli.output,
-        ` in ${script}:9`,
+        `break in ${script}:9`,
         'hits the 2nd breakpoint because the 1st was cleared');
     })
     .then(() => cli.quit())

--- a/test/cli/exceptions.test.js
+++ b/test/cli/exceptions.test.js
@@ -17,7 +17,7 @@ test('break on (uncaught) exceptions', (t) => {
   return cli.waitForInitialBreak()
     .then(() => cli.waitForPrompt())
     .then(() => {
-      t.match(cli.output, ` in ${script}:1`);
+      t.match(cli.output, `break in ${script}:1`);
     })
     // making sure it will die by default:
     .then(() => cli.command('c'))
@@ -26,8 +26,9 @@ test('break on (uncaught) exceptions', (t) => {
 
     // Next run: With `breakOnException` it pauses in both places
     .then(() => cli.stepCommand('r'))
+    .then(() => cli.waitForInitialBreak())
     .then(() => {
-      t.match(cli.output, ` in ${script}:1`);
+      t.match(cli.output, `break in ${script}:1`);
     })
     .then(() => cli.command('breakOnException'))
     .then(() => cli.stepCommand('c'))
@@ -42,8 +43,9 @@ test('break on (uncaught) exceptions', (t) => {
     // Next run: With `breakOnUncaught` it only pauses on the 2nd exception
     .then(() => cli.command('breakOnUncaught'))
     .then(() => cli.stepCommand('r')) // also, the setting survives the restart
+    .then(() => cli.waitForInitialBreak())
     .then(() => {
-      t.match(cli.output, ` in ${script}:1`);
+      t.match(cli.output, `break in ${script}:1`);
     })
     .then(() => cli.stepCommand('c'))
     .then(() => {
@@ -53,8 +55,9 @@ test('break on (uncaught) exceptions', (t) => {
     // Next run: Back to the initial state! It should die again.
     .then(() => cli.command('breakOnNone'))
     .then(() => cli.stepCommand('r'))
+    .then(() => cli.waitForInitialBreak())
     .then(() => {
-      t.match(cli.output, ` in ${script}:1`);
+      t.match(cli.output, `break in ${script}:1`);
     })
     .then(() => cli.command('c'))
     // TODO: Remove FATAL ERROR once node doesn't show a FATAL ERROR anymore

--- a/test/cli/exceptions.test.js
+++ b/test/cli/exceptions.test.js
@@ -14,10 +14,10 @@ test('break on (uncaught) exceptions', (t) => {
     throw error;
   }
 
-  return cli.waitFor(/break/)
+  return cli.waitForInitialBreak()
     .then(() => cli.waitForPrompt())
     .then(() => {
-      t.match(cli.output, `break in ${script}:1`);
+      t.match(cli.output, ` in ${script}:1`);
     })
     // making sure it will die by default:
     .then(() => cli.command('c'))
@@ -26,7 +26,7 @@ test('break on (uncaught) exceptions', (t) => {
     // Next run: With `breakOnException` it pauses in both places
     .then(() => cli.stepCommand('r'))
     .then(() => {
-      t.match(cli.output, `break in ${script}:1`);
+      t.match(cli.output, ` in ${script}:1`);
     })
     .then(() => cli.command('breakOnException'))
     .then(() => cli.stepCommand('c'))
@@ -42,7 +42,7 @@ test('break on (uncaught) exceptions', (t) => {
     .then(() => cli.command('breakOnUncaught'))
     .then(() => cli.stepCommand('r')) // also, the setting survives the restart
     .then(() => {
-      t.match(cli.output, `break in ${script}:1`);
+      t.match(cli.output, ` in ${script}:1`);
     })
     .then(() => cli.stepCommand('c'))
     .then(() => {
@@ -53,7 +53,7 @@ test('break on (uncaught) exceptions', (t) => {
     .then(() => cli.command('breakOnNone'))
     .then(() => cli.stepCommand('r'))
     .then(() => {
-      t.match(cli.output, `break in ${script}:1`);
+      t.match(cli.output, ` in ${script}:1`);
     })
     .then(() => cli.command('c'))
     .then(() => cli.waitFor(/disconnect/))

--- a/test/cli/exceptions.test.js
+++ b/test/cli/exceptions.test.js
@@ -21,7 +21,8 @@ test('break on (uncaught) exceptions', (t) => {
     })
     // making sure it will die by default:
     .then(() => cli.command('c'))
-    .then(() => cli.waitFor(/disconnect/))
+    // TODO: Remove FATAL ERROR once node doesn't show a FATAL ERROR anymore
+    .then(() => cli.waitFor(/disconnect|FATAL ERROR/))
 
     // Next run: With `breakOnException` it pauses in both places
     .then(() => cli.stepCommand('r'))
@@ -56,7 +57,8 @@ test('break on (uncaught) exceptions', (t) => {
       t.match(cli.output, ` in ${script}:1`);
     })
     .then(() => cli.command('c'))
-    .then(() => cli.waitFor(/disconnect/))
+    // TODO: Remove FATAL ERROR once node doesn't show a FATAL ERROR anymore
+    .then(() => cli.waitFor(/disconnect|FATAL ERROR/))
 
     .then(() => cli.quit())
     .then(null, onFatal);

--- a/test/cli/exec.test.js
+++ b/test/cli/exec.test.js
@@ -11,7 +11,7 @@ test('examples/alive.js', (t) => {
     throw error;
   }
 
-  return cli.waitFor(/break/)
+  return cli.waitForInitialBreak()
     .then(() => cli.waitForPrompt())
     .then(() => cli.command('exec [typeof heartbeat, typeof process.exit]'))
     .then(() => {
@@ -60,7 +60,7 @@ test('exec .scope', (t) => {
     throw error;
   }
 
-  return cli.waitFor(/break/)
+  return cli.waitForInitialBreak()
     .then(() => cli.waitForPrompt())
     .then(() => cli.stepCommand('c'))
     .then(() => cli.command('exec .scope'))

--- a/test/cli/help.test.js
+++ b/test/cli/help.test.js
@@ -11,7 +11,7 @@ test('examples/empty.js', (t) => {
     throw error;
   }
 
-  return cli.waitFor(/break/)
+  return cli.waitForInitialBreak()
     .then(() => cli.waitForPrompt())
     .then(() => cli.command('help'))
     .then(() => {

--- a/test/cli/launch.test.js
+++ b/test/cli/launch.test.js
@@ -5,18 +5,14 @@ const { test } = require('tap');
 
 const startCLI = require('./start-cli');
 
-test('examples/empty.js', (t) => {
-  const script = Path.join('examples', 'empty.js');
+test('examples/three-lines.js', (t) => {
+  const script = Path.join('examples', 'three-lines.js');
   const cli = startCLI([script]);
 
   return cli.waitForInitialBreak()
     .then(() => cli.waitForPrompt())
     .then(() => {
       t.match(cli.output, 'debug>', 'prints a prompt');
-      t.match(
-        cli.output,
-        '< Debugger listening on port 9229',
-        'forwards child output');
     })
     .then(() => cli.command('["hello", "world"].join(" ")'))
     .then(() => {
@@ -72,6 +68,7 @@ test('run after quit / restart', (t) => {
       t.match(cli.output, 'Use `run` to start the app again');
     })
     .then(() => cli.stepCommand('run'))
+    .then(() => cli.waitForInitialBreak())
     .then(() => cli.waitForPrompt())
     .then(() => {
       t.match(
@@ -87,6 +84,7 @@ test('run after quit / restart', (t) => {
         'steps to the 2nd line');
     })
     .then(() => cli.stepCommand('restart'))
+    .then(() => cli.waitForInitialBreak())
     .then(() => {
       t.match(
         cli.output,
@@ -100,6 +98,7 @@ test('run after quit / restart', (t) => {
       t.match(cli.output, 'Use `run` to start the app again');
     })
     .then(() => cli.stepCommand('run'))
+    .then(() => cli.waitForInitialBreak())
     .then(() => cli.waitForPrompt())
     .then(() => {
       t.match(

--- a/test/cli/launch.test.js
+++ b/test/cli/launch.test.js
@@ -9,7 +9,7 @@ test('examples/empty.js', (t) => {
   const script = Path.join('examples', 'empty.js');
   const cli = startCLI([script]);
 
-  return cli.waitFor(/break/)
+  return cli.waitForInitialBreak()
     .then(() => cli.waitForPrompt())
     .then(() => {
       t.match(cli.output, 'debug>', 'prints a prompt');
@@ -45,7 +45,7 @@ test('run after quit / restart', (t) => {
     throw error;
   }
 
-  return cli.waitFor(/break/)
+  return cli.waitForInitialBreak()
     .then(() => cli.waitForPrompt())
     .then(() => cli.stepCommand('n'))
     .then(() => {

--- a/test/cli/low-level.test.js
+++ b/test/cli/low-level.test.js
@@ -4,8 +4,8 @@ const { test } = require('tap');
 const startCLI = require('./start-cli');
 
 test('Debugger agent direct access', (t) => {
-  const cli = startCLI(['examples/empty.js']);
-  const scriptPattern = /^\* (\d+): examples(?:\/|\\)empty.js/;
+  const cli = startCLI(['examples/three-lines.js']);
+  const scriptPattern = /^\* (\d+): examples(?:\/|\\)three-lines.js/;
 
   function onFatal(error) {
     cli.quit();
@@ -24,7 +24,10 @@ test('Debugger agent direct access', (t) => {
     .then(() => {
       t.match(
         cli.output,
-        /scriptSource: '\(function \([^)]+\) \{ \\n}\);'/);
+        /scriptSource: '\(function \(/);
+      t.match(
+        cli.output,
+        /let x = 1;/);
     })
     .then(() => cli.quit())
     .then(null, onFatal);

--- a/test/cli/low-level.test.js
+++ b/test/cli/low-level.test.js
@@ -12,7 +12,7 @@ test('Debugger agent direct access', (t) => {
     throw error;
   }
 
-  return cli.waitFor(/break/)
+  return cli.waitForInitialBreak()
     .then(() => cli.waitForPrompt())
     .then(() => cli.command('scripts'))
     .then(() => {

--- a/test/cli/preserve-breaks.test.js
+++ b/test/cli/preserve-breaks.test.js
@@ -33,8 +33,7 @@ test('run after quit / restart', (t) => {
       t.match(cli.output, `break in ${script}:3`);
     })
     .then(() => cli.command('restart'))
-    .then(() => cli.waitFor([/break in examples/, /breakpoints restored/]))
-    .then(() => cli.waitForPrompt())
+    .then(() => cli.waitForInitialBreak())
     .then(() => {
       t.match(cli.output, `break in ${script}:1`);
     })

--- a/test/cli/preserve-breaks.test.js
+++ b/test/cli/preserve-breaks.test.js
@@ -14,7 +14,7 @@ test('run after quit / restart', (t) => {
     throw error;
   }
 
-  return cli.waitFor(/break/)
+  return cli.waitForInitialBreak()
     .then(() => cli.waitForPrompt())
     .then(() => cli.command('breakpoints'))
     .then(() => {

--- a/test/cli/profile.test.js
+++ b/test/cli/profile.test.js
@@ -15,7 +15,7 @@ test('profiles', (t) => {
     throw error;
   }
 
-  return cli.waitFor(/break/)
+  return cli.waitForInitialBreak()
     .then(() => cli.waitForPrompt())
     .then(() => cli.command('exec console.profile()'))
     .then(() => {

--- a/test/cli/scripts.test.js
+++ b/test/cli/scripts.test.js
@@ -14,7 +14,7 @@ test('list scripts', (t) => {
     throw error;
   }
 
-  return cli.waitFor(/break/)
+  return cli.waitForInitialBreak()
     .then(() => cli.waitForPrompt())
     .then(() => cli.command('scripts'))
     .then(() => {

--- a/test/cli/scripts.test.js
+++ b/test/cli/scripts.test.js
@@ -6,7 +6,7 @@ const { test } = require('tap');
 const startCLI = require('./start-cli');
 
 test('list scripts', (t) => {
-  const script = Path.join('examples', 'empty.js');
+  const script = Path.join('examples', 'three-lines.js');
   const cli = startCLI([script]);
 
   function onFatal(error) {
@@ -20,7 +20,7 @@ test('list scripts', (t) => {
     .then(() => {
       t.match(
         cli.output,
-        /^\* \d+: examples(?:\/|\\)empty\.js/,
+        /^\* \d+: examples(?:\/|\\)three-lines\.js/,
         'lists the user script');
       t.notMatch(
         cli.output,
@@ -31,7 +31,7 @@ test('list scripts', (t) => {
     .then(() => {
       t.match(
         cli.output,
-        /\* \d+: examples(?:\/|\\)empty\.js/,
+        /\* \d+: examples(?:\/|\\)three-lines\.js/,
         'lists the user script');
       t.match(
         cli.output,

--- a/test/cli/start-cli.js
+++ b/test/cli/start-cli.js
@@ -93,6 +93,10 @@ function startCLI(args) {
       return this.waitFor(/>\s+$/, timeout);
     },
 
+    waitForInitialBreak(timeout = 2000) {
+      return this.waitFor(/break/i, timeout);
+    },
+
     ctrlC() {
       return this.command('.interrupt');
     },

--- a/test/cli/start-cli.js
+++ b/test/cli/start-cli.js
@@ -1,6 +1,11 @@
 'use strict';
 const spawn = require('child_process').spawn;
 
+// This allows us to keep the helper inside of `test/` without tap warning
+// about "pending" test files.
+const tap = require('tap');
+tap.test('startCLI', (t) => t.end());
+
 const CLI =
   process.env.USE_EMBEDDED_NODE_INSPECT === '1' ?
   'inspect' :

--- a/test/cli/use-strict.test.js
+++ b/test/cli/use-strict.test.js
@@ -14,7 +14,7 @@ test('for whiles that starts with strict directive', (t) => {
     throw error;
   }
 
-  return cli.waitFor(/break/)
+  return cli.waitForInitialBreak()
     .then(() => cli.waitForPrompt())
     .then(() => {
       t.match(

--- a/test/cli/watchers.test.js
+++ b/test/cli/watchers.test.js
@@ -11,7 +11,7 @@ test('stepping through breakpoints', (t) => {
     throw error;
   }
 
-  return cli.waitFor(/break/)
+  return cli.waitForInitialBreak()
     .then(() => cli.waitForPrompt())
     .then(() => cli.command('watch("x")'))
     .then(() => cli.command('watch("\\"Hello\\"")'))

--- a/test/node-inspect.test.js
+++ b/test/node-inspect.test.js
@@ -1,9 +1,0 @@
-'use strict';
-const tap = require('tap');
-
-const nodeInspect = require('../');
-
-tap.equal(
-  9229,
-  nodeInspect.port,
-  'Uses the --inspect default port');


### PR DESCRIPTION
The port export [no longer exists](https://github.com/nodejs/node-inspect/pull/26) and isn't in use. It was a hold-over from the old built-in debugger.