### PR TITLE
test: custom port

### DIFF
--- a/lib/_inspect.js
+++ b/lib/_inspect.js
@@ -42,7 +42,7 @@ const [ InspectClient, createRepl ] =
 
 const debuglog = util.debuglog('inspect');
 
-const DEBUG_PORT_PATTERN = /^--(?:debug|inspect)-port=(\d+)$/;
+const DEBUG_PORT_PATTERN = /^--(?:debug|inspect)(?:-port|-brk)?=(\d{1,5})$/;
 function getDefaultPort() {
   for (const arg of process.execArgv) {
     const match = arg.match(DEBUG_PORT_PATTERN);
@@ -56,8 +56,7 @@ function getDefaultPort() {
 function runScript(script, scriptArgs, inspectPort, childPrint) {
   return new Promise((resolve) => {
     const args = [
-      '--inspect',
-      `--debug-brk=${inspectPort}`,
+      `--inspect-brk=${inspectPort}`,
     ].concat([script], scriptArgs);
     const child = spawn(process.execPath, args);
     child.stdout.setEncoding('utf8');
@@ -68,7 +67,7 @@ function runScript(script, scriptArgs, inspectPort, childPrint) {
     let output = '';
     function waitForListenHint(text) {
       output += text;
-      if (/chrome-devtools:\/\//.test(output)) {
+      if (/^Debugger listening on/.test(output)) {
         child.stderr.removeListener('data', waitForListenHint);
         resolve(child);
       }
@@ -295,6 +294,7 @@ function parseArgv([target, ...args]) {
 
   const hostMatch = target.match(/^([^:]+):(\d+)$/);
   const portMatch = target.match(/^--port=(\d+)$/);
+
   if (hostMatch) {
     // Connecting to remote debugger
     // `node-inspect localhost:9229`
@@ -303,16 +303,15 @@ function parseArgv([target, ...args]) {
     isRemote = true;
     script = null;
   } else if (portMatch) {
-    // Start debugger on custom port
-    // `node debug --port=8058 app.js`
+    // start debugee on custom port
+    // `node inspect --port=9230 script.js`
     port = parseInt(portMatch[1], 10);
     script = args[0];
     scriptArgs = args.slice(1);
   }
 
   return {
-    host, port,
-    isRemote, script, scriptArgs,
+    host, port, isRemote, script, scriptArgs,
   };
 }
 

--- a/test/cli/launch.test.js
+++ b/test/cli/launch.test.js
@@ -5,6 +5,27 @@ const { test } = require('tap');
 
 const startCLI = require('./start-cli');
 
+test('custom port', (t) => {
+  const CUSTOM_PORT = '9230';
+  const script = Path.join('examples', 'empty.js');
+
+  const cli = startCLI([`--port=${CUSTOM_PORT}`, script]);
+
+  return cli.waitFor(/break/)
+    .then(() => cli.waitForPrompt())
+    .then(() => {
+      t.match(cli.output, 'debug>', 'prints a prompt');
+      t.match(
+        cli.output,
+        `< Debugger listening on port ${CUSTOM_PORT}`,
+        'forwards child output');
+    })
+    .then(() => cli.quit())
+    .then((code) => {
+      t.equal(code, 0, 'exits with success');
+    });
+});
+
 test('examples/empty.js', (t) => {
   const script = Path.join('examples', 'empty.js');
   const cli = startCLI([script]);


### PR DESCRIPTION
* adds a test for a custom port specified with `--port`
* use `--inspect-brk` instead of `--debug-brk`
* fixes regex for default port to consider `--inspect=<port>` and `--inspect-brk=<port>` as well as `--inspect-port=<port>`, since all of these are supported per [src/node_debug_options.cc][0].
* look for 'Debugger listening on..." rather than `chrome-devtools` for better future-proofness.

[0]: https://github.com/nodejs/node/blob/66e7dc558705edb0f473c4df902e9e407a2896c4/src/node_debug_options.cc#L126