### PR TITLE
Prefer --inspect-brk over --debug-brk

### DIFF
--- a/lib/_inspect.js
+++ b/lib/_inspect.js
@@ -96,10 +96,11 @@ function runScript(script, scriptArgs, inspectHost, inspectPort, childPrint) {
   return portIsFree(inspectHost, inspectPort)
     .then(() => {
       return new Promise((resolve) => {
-        const args = [
-          '--inspect',
-          `--debug-brk=${inspectPort}`,
-        ].concat([script], scriptArgs);
+        const needDebugBrk = process.version.match(/^v(6|7)\./);
+        const args = (needDebugBrk ?
+                          ['--inspect', `--debug-brk=${inspectPort}`] :
+                          [`--inspect-brk=${inspectPort}`])
+                         .concat([script], scriptArgs);
         const child = spawn(process.execPath, args);
         child.stdout.setEncoding('utf8');
         child.stderr.setEncoding('utf8');


### PR DESCRIPTION
Node 8.x no longer has --debug-brk and --inspect-brk is backwards
compatible with Node 7.

Ref: https://github.com/nodejs/node/pull/12197.

I will be cherry-picking this on https://github.com/nodejs/node/pull/11441.