### PR TITLE
Bump the tap version

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "eslint": "^3.10.2",
     "nlm": "^3.0.0",
-    "tap": "^7.1.2"
+    "tap": "^10.7.0"
   },
   "author": {
     "name": "Jan Krems",

--- a/test/cli/break.test.js
+++ b/test/cli/break.test.js
@@ -134,7 +134,7 @@ test('sb before loading file', (t) => {
 
   return cli.waitForInitialBreak()
     .then(() => cli.waitForPrompt())
-    .then(() => cli.command('sb("other.js", 3)'))
+    .then(() => cli.command('sb("other.js", 2)'))
     .then(() => {
       t.match(
         cli.output,
@@ -145,7 +145,7 @@ test('sb before loading file', (t) => {
     .then(() => {
       t.match(
         cli.output,
-        `break in ${otherScript}:3`,
+        `break in ${otherScript}:2`,
         'found breakpoint in file that was not loaded yet');
     })
     .then(() => cli.quit())


### PR DESCRIPTION
This gives us access to the `--output-file` option which makes it easier to integrate with CI test result reporting.

Also, for some reason there was a mismatch between the example line numbers and the breakpoint that the test tries to set. Added a fix that makes the test suite pass again consistently.