### PR TITLE
fix: Make `takeHeapSnapshot()` work

### DIFF
--- a/lib/internal/inspect_repl.js
+++ b/lib/internal/inspect_repl.js
@@ -25,6 +25,7 @@ const Path = require('path');
 const Repl = require('repl');
 const util = require('util');
 const vm = require('vm');
+const JSONSplitStream = require('json-split-stream');
 
 const debuglog = util.debuglog('inspect');
 
@@ -900,10 +901,10 @@ function createRepl(inspector) {
         return new Promise((resolve, reject) => {
           const absoluteFile = Path.resolve(filename);
           const writer = FS.createWriteStream(absoluteFile);
-          let totalSize;
+          const jsonChunker = new JSONSplitStream({ storeData: false });
+          jsonChunker.on('finishedJSON', onFinishedJSON);
           let sizeWritten = 0;
           function onProgress({ done, total, finished }) {
-            totalSize = total;
             if (finished) {
               print('Heap snaphost prepared.');
             } else {
@@ -912,14 +913,16 @@ function createRepl(inspector) {
           }
           function onChunk({ chunk }) {
             sizeWritten += chunk.length;
-            writer.write(chunk);
-            print(`Writing snapshot: ${sizeWritten}/${totalSize}`, true);
-            if (sizeWritten >= totalSize) {
-              writer.end();
-              teardown();
-              print(`Wrote snapshot: ${absoluteFile}`);
-              resolve();
-            }
+            writer.write(chunk, () => {
+              print(`Writing snapshot: ${sizeWritten} bytes`, true);
+              jsonChunker.write(chunk);
+            });
+          }
+          function onFinishedJSON() {
+            writer.end();
+            teardown();
+            print(`Wrote snapshot: ${absoluteFile} (${sizeWritten} bytes)`);
+            resolve();
           }
           function teardown() {
             HeapProfiler.removeListener(

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
       ]
     }
   },
-  "dependencies": {},
+  "dependencies": {
+    "json-split-stream": "^1.1.0"
+  },
   "devDependencies": {
     "eslint": "^3.10.2",
     "nlm": "^3.0.0",


### PR DESCRIPTION
Instead of treating the total item count like an expected
byte length, wait for the JSON data to end before considering
the heap snapshot finished.

Fixes: https://github.com/nodejs/node-inspect/issues/56

@jkrems This PR would, in its current state, introduce a dependency (that I wrote specifically for this use case)… I have no idea how okay that is. It might also make embedding into Node slightly trickier, so I’d also be okay with just copying in the dependency `index.js` as-is?