### PR TITLE
fix: Fix `takeHeapSnapshot()` truncation bug

### DIFF
--- a/test/cli/heap-profiler.test.js
+++ b/test/cli/heap-profiler.test.js
@@ -1,0 +1,34 @@
+'use strict';
+const { test } = require('tap');
+const { readFileSync, unlinkSync } = require('fs');
+
+const startCLI = require('./start-cli');
+const filename = 'node.heapsnapshot';
+
+function cleanup() {
+  try {
+    unlinkSync(filename);
+  } catch (_) {
+    // Ignore.
+  }
+}
+
+cleanup();
+
+test('Heap profiler take snapshot', (t) => {
+  const cli = startCLI(['examples/empty.js']);
+
+  function onFatal(error) {
+    cli.quit();
+    throw error;
+  }
+
+  // Check that the snapshot is valid JSON.
+  return cli.waitForInitialBreak()
+    .then(() => cli.waitForPrompt())
+    .then(() => cli.command('takeHeapSnapshot()'))
+    .then(() => JSON.parse(readFileSync(filename, 'utf8')))
+    .then(() => cleanup())
+    .then(() => cli.quit())
+    .then(null, onFatal);
+});


### PR DESCRIPTION
Fix a logic bug in `takeHeapSnapshot()` where it interpreted the item
count as the byte count, resulting in truncated snapshots.

This change hinges on the observation that the completion callback
always comes after any and all `'addHeapSnapshotChunk'` events.

I'm 95% sure after digging into the V8 inspector and its integration
with Node.js that the assumption above is correct.

If it turns out I'm mistaken, then we will most likely treat that as
a bug in Node.js, not node-inspect.

Fixes: https://github.com/nodejs/node-inspect/issues/56