### PR TITLE
fix: replace the deprecated "repl.cli" with "repl"

### DIFF
--- a/lib/_inspect.js
+++ b/lib/_inspect.js
@@ -198,7 +198,7 @@ class NodeInspector {
 
   suspendReplWhile(fn) {
     if (this.repl) {
-      this.repl.rli.pause();
+      this.repl.pause();
     }
     this.stdin.pause();
     this.paused = true;
@@ -207,7 +207,7 @@ class NodeInspector {
     }).then(() => {
       this.paused = false;
       if (this.repl) {
-        this.repl.rli.resume();
+        this.repl.resume();
         this.repl.displayPrompt();
       }
       this.stdin.resume();

--- a/lib/internal/inspect_repl.js
+++ b/lib/internal/inspect_repl.js
@@ -958,8 +958,8 @@ function createRepl(inspector) {
 
       get repl() {
         // Don't display any default messages
-        const listeners = repl.rli.listeners('SIGINT').slice(0);
-        repl.rli.removeAllListeners('SIGINT');
+        const listeners = repl.listeners('SIGINT').slice(0);
+        repl.removeAllListeners('SIGINT');
 
         const oldContext = repl.context;
 
@@ -967,7 +967,7 @@ function createRepl(inspector) {
           // Restore all listeners
           process.nextTick(() => {
             listeners.forEach((listener) => {
-              repl.rli.on('SIGINT', listener);
+              repl.on('SIGINT', listener);
             });
           });
 
@@ -975,21 +975,21 @@ function createRepl(inspector) {
           repl.eval = controlEval;
 
           // Swap history
-          history.debug = repl.rli.history;
-          repl.rli.history = history.control;
+          history.debug = repl.history;
+          repl.history = history.control;
 
           repl.context = oldContext;
-          repl.rli.setPrompt('debug> ');
+          repl.setPrompt('debug> ');
           repl.displayPrompt();
 
-          repl.rli.removeListener('SIGINT', exitDebugRepl);
+          repl.removeListener('SIGINT', exitDebugRepl);
           repl.removeListener('exit', exitDebugRepl);
 
           exitDebugRepl = null;
         };
 
         // Exit debug repl on SIGINT
-        repl.rli.on('SIGINT', exitDebugRepl);
+        repl.on('SIGINT', exitDebugRepl);
 
         // Exit debug repl on repl exit
         repl.on('exit', exitDebugRepl);
@@ -999,10 +999,10 @@ function createRepl(inspector) {
         repl.context = {};
 
         // Swap history
-        history.control = repl.rli.history;
-        repl.rli.history = history.debug;
+        history.control = repl.history;
+        repl.history = history.debug;
 
-        repl.rli.setPrompt('> ');
+        repl.setPrompt('> ');
 
         print('Press Ctrl + C to leave debug repl');
         repl.displayPrompt();
@@ -1077,7 +1077,7 @@ function createRepl(inspector) {
 
     repl.defineCommand('interrupt', () => {
       // We want this for testing purposes where sending CTRL-C can be tricky.
-      repl.rli.emit('SIGINT');
+      repl.emit('SIGINT');
     });
 
     // Init once for the initial connection


### PR DESCRIPTION
"REPLServer.rli" is deprecated and it's the reference of
the instance. So that we can replace the "repl.cli" with
"repl" to remove the deprecation warning in Node.js 12.

Refs: https://github.com/nodejs/node/pull/26260