### PR TITLE
Address regressions due to changes in node

### DIFF
--- a/lib/internal/inspect_repl.js
+++ b/lib/internal/inspect_repl.js
@@ -25,6 +25,7 @@ const Path = require('path');
 const Repl = require('repl');
 const util = require('util');
 const vm = require('vm');
+const fileURLToPath = require('url').fileURLToPath;
 
 const debuglog = util.debuglog('inspect');
 
@@ -89,8 +90,11 @@ function isNativeUrl(url) {
   return url.replace('.js', '') in NATIVES || url === 'bootstrap_node.js';
 }
 
-function getRelativePath(filename) {
+function getRelativePath(filenameOrURL) {
   const dir = Path.join(Path.resolve(), 'x').slice(0, -1);
+
+  const filename = filenameOrURL.startsWith('file://') ?
+    fileURLToPath(filenameOrURL) : filenameOrURL;
 
   // Change path to relative, if possible
   if (filename.indexOf(dir) === 0) {

--- a/test/cli/break.test.js
+++ b/test/cli/break.test.js
@@ -18,12 +18,12 @@ test('stepping through breakpoints', (t) => {
     .then(() => cli.waitForPrompt())
     .then(() => {
       t.match(
-        cli.output,
-        `break in ${script}:1`,
+        cli.breakInfo,
+        { filename: script, line: 1 },
         'pauses in the first line of the script');
       t.match(
         cli.output,
-        /> 1 \(function \([^)]+\) \{ const x = 10;/,
+        /> 1 (?:\(function \([^)]+\) \{ )?const x = 10;/,
         'shows the source and marks the current line');
     })
     .then(() => cli.stepCommand('n'))

--- a/test/cli/exceptions.test.js
+++ b/test/cli/exceptions.test.js
@@ -17,7 +17,7 @@ test('break on (uncaught) exceptions', (t) => {
   return cli.waitForInitialBreak()
     .then(() => cli.waitForPrompt())
     .then(() => {
-      t.match(cli.output, `break in ${script}:1`);
+      t.match(cli.breakInfo, { filename: script, line: 1 });
     })
     // making sure it will die by default:
     .then(() => cli.command('c'))
@@ -28,7 +28,7 @@ test('break on (uncaught) exceptions', (t) => {
     .then(() => cli.stepCommand('r'))
     .then(() => cli.waitForInitialBreak())
     .then(() => {
-      t.match(cli.output, `break in ${script}:1`);
+      t.match(cli.breakInfo, { filename: script, line: 1 });
     })
     .then(() => cli.command('breakOnException'))
     .then(() => cli.stepCommand('c'))
@@ -45,7 +45,7 @@ test('break on (uncaught) exceptions', (t) => {
     .then(() => cli.stepCommand('r')) // also, the setting survives the restart
     .then(() => cli.waitForInitialBreak())
     .then(() => {
-      t.match(cli.output, `break in ${script}:1`);
+      t.match(cli.breakInfo, { filename: script, line: 1 });
     })
     .then(() => cli.stepCommand('c'))
     .then(() => {
@@ -57,7 +57,7 @@ test('break on (uncaught) exceptions', (t) => {
     .then(() => cli.stepCommand('r'))
     .then(() => cli.waitForInitialBreak())
     .then(() => {
-      t.match(cli.output, `break in ${script}:1`);
+      t.match(cli.breakInfo, { filename: script, line: 1 });
     })
     .then(() => cli.command('c'))
     // TODO: Remove FATAL ERROR once node doesn't show a FATAL ERROR anymore

--- a/test/cli/launch.test.js
+++ b/test/cli/launch.test.js
@@ -137,23 +137,23 @@ test('run after quit / restart', (t) => {
     .then(() => cli.waitForPrompt())
     .then(() => {
       t.match(
-        cli.output,
-        `break in ${script}:1`,
+        cli.breakInfo,
+        { filename: script, line: 1 },
         'is back at the beginning');
     })
     .then(() => cli.stepCommand('n'))
     .then(() => {
       t.match(
-        cli.output,
-        `break in ${script}:2`,
+        cli.breakInfo,
+        { filename: script, line: 2 },
         'steps to the 2nd line');
     })
     .then(() => cli.stepCommand('restart'))
     .then(() => cli.waitForInitialBreak())
     .then(() => {
       t.match(
-        cli.output,
-        `break in ${script}:1`,
+        cli.breakInfo,
+        { filename: script, line: 1 },
         'is back at the beginning');
     })
     .then(() => cli.command('kill'))
@@ -167,8 +167,8 @@ test('run after quit / restart', (t) => {
     .then(() => cli.waitForPrompt())
     .then(() => {
       t.match(
-        cli.output,
-        `break in ${script}:1`,
+        cli.breakInfo,
+        { filename: script, line: 1 },
         'is back at the beginning');
     })
     .then(() => cli.quit())

--- a/test/cli/low-level.test.js
+++ b/test/cli/low-level.test.js
@@ -24,7 +24,7 @@ test('Debugger agent direct access', (t) => {
     .then(() => {
       t.match(
         cli.output,
-        /scriptSource: '\(function \(/);
+        /scriptSource:[ \n]*'(?:\(function \(|let x = 1)/);
       t.match(
         cli.output,
         /let x = 1;/);

--- a/test/cli/preserve-breaks.test.js
+++ b/test/cli/preserve-breaks.test.js
@@ -30,20 +30,20 @@ test('run after quit / restart', (t) => {
     .then(() => cli.stepCommand('c')) // hit line 2
     .then(() => cli.stepCommand('c')) // hit line 3
     .then(() => {
-      t.match(cli.output, `break in ${script}:3`);
+      t.match(cli.breakInfo, { filename: script, line: 3 });
     })
     .then(() => cli.command('restart'))
     .then(() => cli.waitForInitialBreak())
     .then(() => {
-      t.match(cli.output, `break in ${script}:1`);
+      t.match(cli.breakInfo, { filename: script, line: 1 });
     })
     .then(() => cli.stepCommand('c'))
     .then(() => {
-      t.match(cli.output, `break in ${script}:2`);
+      t.match(cli.breakInfo, { filename: script, line: 2 });
     })
     .then(() => cli.stepCommand('c'))
     .then(() => {
-      t.match(cli.output, `break in ${script}:3`);
+      t.match(cli.breakInfo, { filename: script, line: 3 });
     })
     .then(() => cli.command('breakpoints'))
     .then(() => {

--- a/test/cli/scripts.test.js
+++ b/test/cli/scripts.test.js
@@ -24,7 +24,7 @@ test('list scripts', (t) => {
         'lists the user script');
       t.notMatch(
         cli.output,
-        /\d+: module\.js <native>/,
+        /\d+: buffer\.js <native>/,
         'omits node-internal scripts');
     })
     .then(() => cli.command('scripts(true)'))
@@ -35,7 +35,7 @@ test('list scripts', (t) => {
         'lists the user script');
       t.match(
         cli.output,
-        /\d+: module\.js <native>/,
+        /\d+: buffer\.js <native>/,
         'includes node-internal scripts');
     })
     .then(() => cli.quit())

--- a/test/cli/use-strict.test.js
+++ b/test/cli/use-strict.test.js
@@ -17,9 +17,10 @@ test('for whiles that starts with strict directive', (t) => {
   return cli.waitForInitialBreak()
     .then(() => cli.waitForPrompt())
     .then(() => {
+      const brk = cli.breakInfo;
       t.match(
-        cli.output,
-        /break in [^:]+:(?:1|2)[^\d]/,
+        `${brk.line}`,
+        /^(1|2)$/,
         'pauses either on strict directive or first "real" line');
     })
     .then(() => cli.quit())


### PR DESCRIPTION
- [x] Handle switch to file URLs
- [x] Handle change in sourceText formatting (different new lines, no more CJS wrapper)
- [x] Handle change in step behavior (there is no more break step at the beginning of the CJS wrapper function)

To clean up the breakpoint matching, I pulled that regex into a dedicated helper in the test harness for launching the CLI.