### PR TITLE
chore: Update dependencies

### DIFF
--- a/lib/_inspect.js
+++ b/lib/_inspect.js
@@ -30,15 +30,15 @@ const runAsStandalone = typeof __dirname !== 'undefined';
 const [ InspectClient, createRepl ] =
   runAsStandalone ?
   // This copy of node-inspect is on-disk, relative paths make sense.
-  [
-    require('./internal/inspect_client'),
-    require('./internal/inspect_repl')
-  ] :
+    [
+      require('./internal/inspect_client'),
+      require('./internal/inspect_repl')
+    ] :
   // This copy of node-inspect is built into the node executable.
-  [
-    require('node-inspect/lib/internal/inspect_client'),
-    require('node-inspect/lib/internal/inspect_repl')
-  ];
+    [
+      require('node-inspect/lib/internal/inspect_client'),
+      require('node-inspect/lib/internal/inspect_repl')
+    ];
 
 const debuglog = util.debuglog('inspect');
 
@@ -50,7 +50,7 @@ class StartupError extends Error {
 }
 
 function portIsFree(host, port, timeout = 2000) {
-  if (port === 0) return Promise.resolve();  // Binding to a random port.
+  if (port === 0) return Promise.resolve(); // Binding to a random port.
 
   const retryDelay = 150;
   let didTimeOut = false;
@@ -96,9 +96,9 @@ function runScript(script, scriptArgs, inspectHost, inspectPort, childPrint) {
       return new Promise((resolve) => {
         const needDebugBrk = process.version.match(/^v(6|7)\./);
         const args = (needDebugBrk ?
-                          ['--inspect', `--debug-brk=${inspectPort}`] :
-                          [`--inspect-brk=${inspectPort}`])
-                         .concat([script], scriptArgs);
+          ['--inspect', `--debug-brk=${inspectPort}`] :
+          [`--inspect-brk=${inspectPort}`])
+          .concat([script], scriptArgs);
         const child = spawn(process.execPath, args);
         child.stdout.setEncoding('utf8');
         child.stderr.setEncoding('utf8');
@@ -154,11 +154,11 @@ class NodeInspector {
 
     if (options.script) {
       this._runScript = runScript.bind(null,
-                                       options.script,
-                                       options.scriptArgs,
-                                       options.host,
-                                       options.port,
-                                       this.childPrint.bind(this));
+        options.script,
+        options.scriptArgs,
+        options.host,
+        options.port,
+        this.childPrint.bind(this));
     } else {
       this._runScript =
           () => Promise.resolve([null, options.port, options.host]);
@@ -333,8 +333,8 @@ function parseArgv([target, ...args]) {
 }
 
 function startInspect(argv = process.argv.slice(2),
-                      stdin = process.stdin,
-                      stdout = process.stdout) {
+  stdin = process.stdin,
+  stdout = process.stdout) {
   /* eslint-disable no-console */
   if (argv.length < 1) {
     const invokedAs = runAsStandalone ?

--- a/package.json
+++ b/package.json
@@ -27,9 +27,9 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "eslint": "^3.10.2",
+    "eslint": "^6.0.1",
     "nlm": "^3.0.0",
-    "tap": "^10.7.0"
+    "tap": "^14.4.2"
   },
   "author": {
     "name": "Jan Krems",

--- a/test/cli/invalid-args.test.js
+++ b/test/cli/invalid-args.test.js
@@ -27,7 +27,7 @@ test('launch w/ invalid host:port', (t) => {
     });
 });
 
-test('launch w/ unavailable port', async (t) => {
+test('launch w/ unavailable port', async(t) => {
   const blocker = createServer((socket) => socket.end());
   const port = await new Promise((resolve, reject) => {
     blocker.on('error', reject);

--- a/test/cli/start-cli.js
+++ b/test/cli/start-cli.js
@@ -8,8 +8,8 @@ tap.test('startCLI', (t) => t.end());
 
 const CLI =
   process.env.USE_EMBEDDED_NODE_INSPECT === '1' ?
-  'inspect' :
-  require.resolve('../../cli.js');
+    'inspect' :
+    require.resolve('../../cli.js');
 
 const BREAK_MESSAGE = new RegExp('(?:' + [
   'assert', 'break', 'break on start', 'debugCommand',


### PR DESCRIPTION
Update ESLint and tap to quell warnings from `npm audit` and the
GitHub interface.

ESLint update required some changes to other files as indentation rules
are now more strictly enforced.

I'm seeing tests failing locally but that was the case before I updated
anything too, so hopefully this passes on Travis-CI or whatever.