### PR TITLE
"portIsFree" function's "timeout" parameter value increased to solve issues #48, #54 and #70

### DIFF
--- a/lib/_inspect.js
+++ b/lib/_inspect.js
@@ -49,7 +49,7 @@ class StartupError extends Error {
   }
 }
 
-function portIsFree(host, port, timeout = 2000) {
+function portIsFree(host, port, timeout = 9999) {
   if (port === 0) return Promise.resolve(); // Binding to a random port.
 
   const retryDelay = 150;


### PR DESCRIPTION
In windows, assigning a port may take a little longer than previously assumed value of 2000ms.

I am using Windows 10 1903 64bit, and it takes about 3000ms to initialize a port.

I increased the timeout to some higher value (9999ms) to give a little more space to Windows to initialize a port to use with the app.

This patch probably solves issues #48, #54 and #70