### PR TITLE
fix: Avoid using process.binding()

### DIFF
--- a/lib/internal/inspect_repl.js
+++ b/lib/internal/inspect_repl.js
@@ -85,9 +85,16 @@ function extractFunctionName(description) {
   return fnNameMatch ? `: ${fnNameMatch[1]}` : '';
 }
 
-const NATIVES = process.binding('natives');
+const PUBLIC_BUILTINS = require('module').builtinModules;
+const NATIVES = PUBLIC_BUILTINS ? process.binding('natives') : {};
 function isNativeUrl(url) {
-  return url.replace('.js', '') in NATIVES || url === 'bootstrap_node.js';
+  url = url.replace(/\.js$/, '');
+  if (PUBLIC_BUILTINS) {
+    if (url.startsWith('internal/') || PUBLIC_BUILTINS.includes(url))
+      return true;
+  }
+
+  return url in NATIVES || url === 'bootstrap_node';
 }
 
 function getRelativePath(filenameOrURL) {


### PR DESCRIPTION
This is deprecated and emits a warning with `--pending-deprecation`.
I’m afraid I’m not familiar enough with this code to provide a test,
unfortunately.