### PR TITLE
[WIP] chore: Test with GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: Node CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [10.x, 12.x, 13.x]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: npm install, build, and test
+      run: |
+        npm install
+        npm run build --if-present
+        npm test
+      env:
+        CI: true

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "eslint": "^6.0.1",
     "nlm": "^3.0.0",
-    "tap": "^14.4.2"
+    "tap": "^12.7.0"
   },
   "author": {
     "name": "Jan Krems",


### PR DESCRIPTION
Add a workflow to run tests with GitHub Actions.

Based on the standard [Node.js starter workflow](https://github.com/actions/starter-workflows/blob/master/ci/node.js.yml) with the following changes:
- Add `pull_request` event so tests are run on pull requests
- Node.js 8.x removed
- Node.js 13.x added
- `npm ci` replaced with `npm install` as this project doesn't have a `package-lock.json` or shrinkwrap file committed

Tests seem very broken with `tap` 14 so I've downgraded to `tap` 12 where tests pass on Node.js 12.x and 13.x but there are still failures on 10.x (hence this being WIP). Any help with fixing those failures would be appreciated as I'm not that familiar with `node-inspect`.