### PR TITLE
[WIP] chore: Test with GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: Node CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version:
+        # See https://github.com/nodejs/node-inspect/pull/78
+        # - 10.x
+        - 12.x
+        - 13.x
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: npm install, build, and test
+      run: |
+        npm install
+        npm run build --if-present
+        npm test
+      env:
+        CI: true


### PR DESCRIPTION
Add a workflow to run tests with GitHub Actions.

Based on the standard [Node.js starter workflow](https://github.com/actions/starter-workflows/blob/master/ci/node.js.yml) with the following changes:
- Add `pull_request` event so tests are run on pull requests
- Node.js 8.x removed
- Node.js 13.x added
- `fail-fast: false` so that all versions of Node.js are tested (without this as soon as one job fails the rest are canceled)
- `npm ci` replaced with `npm install` as this project doesn't have a `package-lock.json` or shrinkwrap file committed

Tests seem very broken with `tap` 14 so I've downgraded to `tap` 12 where tests pass on Node.js 12.x and 13.x but there are still failures on 10.x (hence this being WIP). Any help with fixing those failures would be appreciated as I'm not that familiar with `node-inspect`.