### PR TITLE
feat: auto-resume on start breakpoint

### DIFF
--- a/lib/_inspect.js
+++ b/lib/_inspect.js
@@ -170,7 +170,19 @@ class NodeInspector {
     this.domainNames.forEach((domain) => {
       this[domain] = createAgentProxy(domain, this.client);
     });
+    let startBreakReached = false;
     this.handleDebugEvent = (fullName, params) => {
+      if (!startBreakReached &&
+          process.env.NODE_INSPECT_RESUME_ON_START === '1' &&
+          fullName === 'Debugger.paused' &&
+          params && params.reason === 'Break on start') {
+        startBreakReached = true;
+        debuglog('Paused on start, but NODE_INSPECT_RESUME_ON_START' +
+                 ' environment variable is set to 1, resuming');
+        this.client.callMethod('Debugger.resume');
+        return;
+      }
+
       const [domain, name] = fullName.split('.');
       if (domain in this) {
         this[domain].emit(name, params);

--- a/lib/_inspect.js
+++ b/lib/_inspect.js
@@ -170,19 +170,7 @@ class NodeInspector {
     this.domainNames.forEach((domain) => {
       this[domain] = createAgentProxy(domain, this.client);
     });
-    let startBreakReached = false;
     this.handleDebugEvent = (fullName, params) => {
-      if (!startBreakReached &&
-          process.env.NODE_INSPECT_RESUME_ON_START === '1' &&
-          fullName === 'Debugger.paused' &&
-          params && params.reason === 'Break on start') {
-        startBreakReached = true;
-        debuglog('Paused on start, but NODE_INSPECT_RESUME_ON_START' +
-                 ' environment variable is set to 1, resuming');
-        this.client.callMethod('Debugger.resume');
-        return;
-      }
-
       const [domain, name] = fullName.split('.');
       if (domain in this) {
         this[domain].emit(name, params);

--- a/lib/internal/inspect_repl.js
+++ b/lib/internal/inspect_repl.js
@@ -782,6 +782,14 @@ function createRepl(inspector) {
   }
 
   Debugger.on('paused', ({ callFrames, reason /* , hitBreakpoints */ }) => {
+    if (process.env.NODE_INSPECT_RESUME_ON_START === '1' &&
+        reason === 'Break on start') {
+      debuglog('Paused on start, but NODE_INSPECT_RESUME_ON_START' +
+              ' environment variable is set to 1, resuming');
+      inspector.client.callMethod('Debugger.resume');
+      return;
+    }
+
     // Save execution context's data
     currentBacktrace = Backtrace.from(callFrames);
     selectedFrame = currentBacktrace[0];

--- a/test/cli/launch.test.js
+++ b/test/cli/launch.test.js
@@ -174,3 +174,23 @@ test('run after quit / restart', (t) => {
     .then(() => cli.quit())
     .then(null, onFatal);
 });
+
+test('auto-resume on start if the environment variable is defined', (t) => {
+  const script = Path.join('examples', 'break.js');
+
+  const cli = startCLI([script], [], {
+    env: { NODE_INSPECT_RESUME_ON_START: '1' }
+  });
+
+  return cli.waitForInitialBreak()
+    .then(() => {
+      t.match(
+        cli.breakInfo,
+        { filename: script, line: 10 },
+        'skips to the first breakpoint');
+    })
+    .then(() => cli.quit())
+    .then((code) => {
+      t.equal(code, 0, 'exits with success');
+    });
+});

--- a/test/cli/start-cli.js
+++ b/test/cli/start-cli.js
@@ -20,8 +20,8 @@ function isPreBreak(output) {
   return /Break on start/.test(output) && /1 \(function \(exports/.test(output);
 }
 
-function startCLI(args, flags = []) {
-  const child = spawn(process.execPath, [...flags, CLI, ...args]);
+function startCLI(args, flags = [], spawnOpts = {}) {
+  const child = spawn(process.execPath, [...flags, CLI, ...args], spawnOpts);
   let isFirstStdoutChunk = true;
 
   const outputBuffer = [];


### PR DESCRIPTION
Fixes #65.

This PR is to automatically resume execution after debugger is paused on start, in case `NODE_INSPECT_RESUME_ON_START` environment variable is set to 1. 