### PR TITLE
feat: implement autocomplete of object/scopes properties

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -145,3 +145,4 @@ globals:
   LTTNG_HTTP_SERVER_RESPONSE: false
   LTTNG_NET_SERVER_CONNECTION: false
   LTTNG_NET_STREAM_END: false
+  BigInt: true

--- a/lib/internal/inspect_repl.js
+++ b/lib/internal/inspect_repl.js
@@ -156,6 +156,69 @@ function convertResultToError(result) {
   return err;
 }
 
+function mergeCompletions(filterStr, completionsList) {
+  const completionSet = new Set();
+  completionsList.forEach((completions) => {
+    if (Array.isArray(completions)) {
+      completions.forEach((completion) => {
+        completionSet.add(completion);
+      });
+    }
+  });
+  return [...completionSet].filter((i) => i.startsWith(filterStr));
+}
+
+// eslint-disable-next-line
+// From: https://github.com/ChromeDevTools/devtools-frontend/blob/674ff27940f84a90812fcd22c368fbe04d9f924b/front_end/object_ui/JavaScriptAutocomplete.js#L442
+function getCompletionsFunc(type) {
+  let object;
+  if (type === 'string') {
+    object = new String('');
+  } else if (type === 'number') {
+    object = new Number(0);
+  } else if (type === 'bigint') {
+    object = Object(BigInt(0));
+  } else if (type === 'boolean') {
+    object = new Boolean(false);
+  } else {
+    object = this;
+  }
+
+  const result = [];
+  try {
+    for (let o = object; o; o = Object.getPrototypeOf(o)) {
+      if ((type === 'array' || type === 'typedarray') &&
+        o === object && o.length > 9999) {
+        continue;
+      }
+
+      const group = {items: [], __proto__: null};
+      try {
+        if (typeof o === 'object'
+          && Object.prototype.hasOwnProperty.call(o, 'constructor')
+          && o.constructor
+          && o.constructor.name) {
+          group.title = o.constructor.name;
+        }
+      } catch (ee) {
+        // we could break upon cross origin check.
+      }
+      result[result.length] = group;
+      const names = Object.getOwnPropertyNames(o);
+      const isArray = Array.isArray(o);
+      for (let i = 0; i < names.length && group.items.length < 10000; ++i) {
+        // Skip array elements indexes.
+        if (isArray && /^[0-9]/.test(names[i])) {
+          continue;
+        }
+        group.items[group.items.length] = names[i];
+      }
+    }
+  } catch (e) {
+  }
+  return result;
+}
+
 class RemoteObject {
   constructor(attributes) {
     Object.assign(this, attributes);
@@ -434,10 +497,10 @@ function createRepl(inspector) {
       Object.assign(this, callFrame);
     }
 
-    loadScopes() {
+    loadScopes(filterGlobal = true) {
       return Promise.all(
         this.scopeChain
-          .filter((scope) => scope.type !== 'global')
+          .filter((scope) => !filterGlobal || scope.type !== 'global')
           .map((scope) => {
             const { objectId } = scope.object;
             return Runtime.getProperties({
@@ -538,6 +601,121 @@ function createRepl(inspector) {
       returnToCallback(null, result);
     } catch (e) {
       returnToCallback(e);
+    }
+  }
+
+  function getScopeProperties() {
+    if (!selectedFrame) {
+      return Promise.resolve([]);
+    }
+
+    return selectedFrame.loadScopes(false).then((scopes) => {
+      const completionSet = new Set();
+      scopes.forEach((scope) => {
+        scope.completionGroup.forEach((completion) => {
+          completionSet.add(completion);
+        });
+      });
+      return [...completionSet.keys()];
+    }).catch((err) => {
+      return [];
+    });
+  }
+
+  function getCompletions(input) {
+    const objectGroup = 'completion';
+    const evalOptions = {
+      expression: input,
+      objectGroup,
+      includeCommandLineAPI: true,
+      silent: true,
+      returnByValue: false,
+      generatePreview: false,
+      throwOnSideEffect: true,
+    };
+    const evaluate = selectedFrame ? Debugger.evaluateOnCallFrame(
+      Object.assign(evalOptions, {
+        callFrameId: selectedFrame.callFrameId
+      })
+    ) : Runtime.evaluate(evalOptions);
+
+    return evaluate.then(({ result }) => {
+      // TODO show "proxy" differently
+      if (result.type === 'object' || result.type === 'function') {
+        return Runtime.callFunctionOn({
+          functionDeclaration: getCompletionsFunc.toString(),
+          objectId: result.objectId,
+          // For now, we only autocomplete "object" and "function"
+          // so that we ignore the "type" argument here.
+          arguments: [],
+          silent: true,
+          returnByValue: true,
+        }).then((ret) => {
+          if (ret.result && Array.isArray(ret.result.value)) {
+            let completions = [];
+            ret.result.value.forEach((group) => {
+              completions = completions.concat(group.items);
+            });
+            return completions;
+          }
+
+          return [];
+        });
+      }
+
+      return [];
+    })
+      .then((ret) => {
+        Runtime.releaseObjectGroup({
+          objectGroup
+        });
+        return ret.sort((a, b) => ((a > b) ? 1 : -1));
+      })
+      .catch(() => ([]));
+  }
+
+  function completer(line, callback) {
+    // eslint-disable-next-line
+    // From: https://github.com/nodejs/node/blob/bcdbd57134558e3bea730f8963881e8865040f6f/lib/repl.js#L1233
+    const simpleExpressionRE
+      = /(?:[a-zA-Z_$](?:\w|\$)*\.)*[a-zA-Z_$](?:\w|\$)*\.?$/;
+    const match = simpleExpressionRE.exec(line);
+    if (line.length !== 0 && !match) {
+      callback(null, [[], line]);
+      return;
+    }
+    const completeOn = (match ? match[0] : '');
+    let expr;
+    let filter;
+    if (line.length === 0) {
+      filter = '';
+      expr = '';
+    } else if (line[line.length - 1] === '.') {
+      filter = '';
+      expr = match[0].slice(0, match[0].length - 1);
+    } else {
+      const bits = match[0].split('.');
+      filter = bits.pop();
+      expr = bits.join('.');
+    }
+
+    if (!expr && selectedFrame) {
+      getScopeProperties()
+        .then((completions) => mergeCompletions(filter, [completions]))
+        .then((completions) => callback(null, [completions, completeOn]));
+    } else if (!expr) {
+      Promise.all([
+        Runtime.globalLexicalScopeNames().then((ret) => ret.names),
+        getCompletions('this')
+      ])
+        .then(mergeCompletions.bind(null, filter))
+        .then((completions) => callback(null, [completions, completeOn]));
+    } else {
+      getCompletions(expr).then((completions) => {
+        const completionsWithExpr = mergeCompletions(filter, [completions])
+          .map((i) => `${expr}.${i}`);
+        callback(null, [completionsWithExpr, completeOn]);
+      });
     }
   }
 
@@ -981,6 +1159,7 @@ function createRepl(inspector) {
         repl.removeAllListeners('SIGINT');
 
         const oldContext = repl.context;
+        const oldCompleter = repl.completer;
 
         exitDebugRepl = () => {
           // Restore all listeners
@@ -992,6 +1171,7 @@ function createRepl(inspector) {
 
           // Exit debug repl
           repl.eval = controlEval;
+          repl.completer = oldCompleter;
 
           // Swap history
           history.debug = repl.history;
@@ -1015,6 +1195,7 @@ function createRepl(inspector) {
 
         // Set new
         repl.eval = debugEval;
+        repl.completer = completer;
         repl.context = {};
 
         // Swap history
@@ -1097,6 +1278,13 @@ function createRepl(inspector) {
     repl.defineCommand('interrupt', () => {
       // We want this for testing purposes where sending CTRL-C can be tricky.
       repl.emit('SIGINT');
+    });
+
+    repl.defineCommand('completer', (name) => {
+      // Use this for testing "completer" as sending "tab" can be tricky.
+      completer(name, (err, [substrs, originalsubstring]) => {
+        print(substrs.join('\n') + '\n');
+      });
     });
 
     // Init once for the initial connection

--- a/test/cli/autocomplete.test.js
+++ b/test/cli/autocomplete.test.js
@@ -1,0 +1,143 @@
+'use strict';
+const { test } = require('tap');
+
+const startCLI = require('./start-cli');
+
+test('repl autocomplete', (t) => {
+  const cli = startCLI(['examples/alive.js']);
+
+  function onFatal(error) {
+    cli.quit();
+    throw error;
+  }
+
+  return cli.waitForInitialBreak()
+    .then(() => cli.waitForPrompt())
+    .then(() => cli.command('repl'))
+    .then(() => cli.waitForPrompt())
+    .then(() => cli.completer(''))
+    .then(() => cli.waitFor(/Array/))
+    .then(() => cli.completer('glo'))
+    .then(() => cli.waitFor(/globalThis/))
+    .then(() => {
+      t.match(
+        cli.output,
+        'global',
+        'could access "global" itself');
+      t.match(
+        cli.output,
+        'globalThis',
+        'could access "globalThis"');
+    })
+    .then(() => cli.completer('global.'))
+    .then(() => cli.waitFor(/global\.Array/))
+    .then(() => cli.completer('global.glo'))
+    .then(() => cli.waitFor(/global\.globalThis/))
+    .then(() => {
+      t.match(
+        cli.output,
+        'global.global');
+      t.match(
+        cli.output,
+        'global.globalThis');
+    })
+    .then(() => cli.completer('global.globalThis'))
+    .then(() => cli.waitFor(/global\.globalThis/))
+    .then(() => {
+      t.notMatch(
+        cli.output,
+        /global\.global\n/);
+      t.match(
+        cli.output,
+        /global\.globalThis/);
+    })
+    .then(() => cli.completer('Arr'))
+    .then(() => cli.waitFor(/ArrayBuffer/))
+    .then(() => {
+      t.match(
+        cli.output,
+        'Array');
+      t.match(
+        cli.output,
+        'ArrayBuffer');
+    })
+    .then(() => cli.completer('process.'))
+    .then(() => cli.waitFor(/process\.versions/))
+    .then(() => {
+      t.match(
+        cli.output,
+        'process.version',
+        'could access property of "version" from "process"');
+    })
+    .then(() => cli.completer('process.version'))
+    .then(() => cli.waitFor(/process\.versions/))
+    .then(() => {
+      t.match(
+        cli.output,
+        'process',
+        '"process" should have both properties of "version" '
+          + 'and "versions" when search for "version"');
+    })
+    .then(() => cli.command('var myUniqueObj = { first: 1, second: 2 }'))
+    .then(() => cli.completer('myUnique'))
+    .then(() => cli.waitFor(/myUniqueObj/))
+    .then(() => cli.completer('myUniqueObj.'))
+    .then(() => cli.waitFor(/second/))
+    .then(() => {
+      t.match(cli.output, 'first', 'shoud print the property "first"');
+      t.match(cli.output, 'second', 'shoud print the property "second"');
+    })
+    .then(() => cli.completer('myUniqueObj.firs'))
+    .then(() => cli.waitFor(/first/))
+    .then(() => {
+      t.match(cli.output, 'myUniqueObj.first');
+      t.notMatch(cli.output, 'second');
+    })
+    .then(() => cli.completer('var a = myUnique'))
+    .then(() => cli.waitFor(/myUniqueObj/))
+    .then(() => {
+      t.match(
+        cli.output,
+        'myUniqueObj',
+        'should complete for a simple sentence');
+    })
+    .then(() => cli.completer('var a = myUniqueObj.firs'))
+    .then(() => cli.waitFor(/first/))
+    .then(() => {
+      t.match(
+        cli.output,
+        'myUniqueObj.first',
+        'should complete for a simple sentence');
+    })
+    .then(() => cli.completer('var a = myUniqueObj.'))
+    .then(() => cli.waitFor(/second/))
+    .then(() => cli.ctrlC())
+    .then(() => cli.waitFor(/debug> $/))
+    .then(() => cli.quit())
+    .then(null, onFatal);
+});
+
+test('repl autocomplete on pause', (t) => {
+  const cli = startCLI(['examples/break.js']);
+
+  function onFatal(error) {
+    cli.quit();
+    throw error;
+  }
+
+  return cli.waitForInitialBreak()
+    .then(() => cli.waitForPrompt())
+    .then(() => cli.stepCommand('c'))
+    .then(() => cli.waitForPrompt())
+    .then(() => cli.command('repl'))
+    .then(() => cli.waitForPrompt())
+    .then(() => cli.completer(''))
+    .then(() => cli.waitFor(/name/))
+    .then(() => {
+      t.match(cli.output, /name\n/, 'show scope variables');
+      t.match(cli.output, /sayHello\n/, 'show scope variables');
+      t.match(cli.output, /Number\n/, 'show properties of global');
+    })
+    .then(() => cli.quit())
+    .then(null, onFatal);
+});

--- a/test/cli/start-cli.js
+++ b/test/cli/start-cli.js
@@ -128,6 +128,14 @@ function startCLI(args, flags = [], spawnOpts = {}) {
       return this.command('.interrupt');
     },
 
+    completer(input) {
+      this.flushOutput();
+      if (!input) {
+        return this.writeLine('.completer');
+      }
+      return this.writeLine(`.completer ${input}`);
+    },
+
     get output() {
       return getOutput();
     },


### PR DESCRIPTION
Refs: #31 

~This is mainly implemented with `Runtime.getProperties`.~

EDIT: I have tried to figure out how [JavaScriptAutocomplete](https://github.com/ChromeDevTools/devtools-frontend/blob/31f1f037b6e94b110ec201cd158322ec5aed3a18/front_end/object_ui/JavaScriptAutocomplete.js) and [repl](https://github.com/nodejs/node/blob/bcdbd57134558e3bea730f8963881e8865040f6f/lib/repl.js#L1233) work and
make this PR (and hope that I have followed them correctly). There are still some features to be finished:

- Display "proxy" like: `Proxy [ { a: 1 }, { b: 2 } ]`, rather than displaying them like objects.
- Separate different groups of properties.
- Autocomplete other types like: string, number. (But it seems that repl also doesn't autocomplete them.)
