### PR TITLE
chore: align message with Node.js standard

### DIFF
--- a/lib/internal/inspect_repl.js
+++ b/lib/internal/inspect_repl.js
@@ -1023,7 +1023,7 @@ function createRepl(inspector) {
 
         repl.setPrompt('> ');
 
-        print('Press Ctrl + C to leave debug repl');
+        print('Press Ctrl+C to leave debug repl');
         repl.displayPrompt();
       },
 
@@ -1095,7 +1095,7 @@ function createRepl(inspector) {
     repl.on('reset', initializeContext);
 
     repl.defineCommand('interrupt', () => {
-      // We want this for testing purposes where sending CTRL-C can be tricky.
+      // We want this for testing purposes where sending Ctrl+C can be tricky.
       repl.emit('SIGINT');
     });
 

--- a/test/cli/exec.test.js
+++ b/test/cli/exec.test.js
@@ -21,7 +21,7 @@ test('examples/alive.js', (t) => {
     .then(() => {
       t.match(
         cli.output,
-        'Press Ctrl + C to leave debug repl\n> ',
+        'Press Ctrl+C to leave debug repl\n> ',
         'shows hint for how to leave repl');
       t.notMatch(cli.output, 'debug>', 'changes the repl style');
     })


### PR DESCRIPTION
Node.js uses (or will use) _Ctrl+C_ with no spaces. To unify the
messages from inspect with other messages from the REPL and elsewhere,
make that change in node-inspect too.