### PR TITLE
chore: bump tap@10.7.0 to tap@12.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "eslint": "^6.8.0",
     "nlm": "^3.0.0",
-    "tap": "^10.7.0"
+    "tap": "^12.7.0"
   },
   "author": {
     "name": "Jan Krems",


### PR DESCRIPTION
tap@10 results in lots of audit warnings when running `npm install`.

tap@13 and above fails some tests as they currently exist.

Using tap@12 means no audit warnings on install and the tests still pass
without modification.