### PR TITLE
refactor: remove unused timeout parameter in portIsFree

### DIFF
--- a/lib/_inspect.js
+++ b/lib/_inspect.js
@@ -49,7 +49,8 @@ class StartupError extends Error {
   }
 }
 
-function portIsFree(host, port, timeout = 9999) {
+function portIsFree(host, port) {
+  const timeout = 9999;
   if (port === 0) return Promise.resolve(); // Binding to a random port.
 
   const retryDelay = 150;


### PR DESCRIPTION
`timeout` is specified as an optional parameter with a default value of
`9999`. `portIsFree` doesn't have any callsites that use this optional
parameter, so this removes the parameter and leaves the timeout value as
a local variable in the function. `portIsFree` isn't exported outside of
`_inspect.js`, so this doesn't change any public function interfaces.