### PR TITLE
lib: remove unused function argument

### DIFF
--- a/lib/internal/inspect_repl.js
+++ b/lib/internal/inspect_repl.js
@@ -577,7 +577,7 @@ function createRepl(inspector) {
         const lines = watchedExpressions
           .map((expr, idx) => {
             const prefix = `${leftPad(idx, ' ', lastIndex)}: ${expr} =`;
-            const value = inspect(values[idx], { colors: true });
+            const value = inspect(values[idx]);
             if (value.indexOf('\n') === -1) {
               return `${prefix} ${value}`;
             }


### PR DESCRIPTION
The `{colors: true}` removed here is ignored by the function it is being
sent to.