### PR TITLE
update: add blackbox by default

### DIFF
--- a/examples/internal-modules.js
+++ b/examples/internal-modules.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const fs = require('fs');
+
+fs.readFile(__filename, function () {});

--- a/lib/internal/inspect_repl.js
+++ b/lib/internal/inspect_repl.js
@@ -1065,7 +1065,7 @@ function createRepl(inspector) {
       Debugger.enable(),
       Debugger.setPauseOnExceptions({ state: 'none' }),
       Debugger.setAsyncCallStackDepth({ maxDepth: 0 }),
-      Debugger.setBlackboxPatterns({ patterns: [] }),
+      Debugger.setBlackboxPatterns({ patterns: ['^node:'] }),
       Debugger.setPauseOnExceptions({ state: pauseOnExceptionState }),
       restoreBreakpoints(),
       Runtime.runIfWaitingForDebugger(),

--- a/test/cli/blackbox.test.js
+++ b/test/cli/blackbox.test.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const Path = require('path');
+
+const { test } = require('tap');
+
+const startCLI = require('./start-cli');
+
+test('breakpoint inside node internal module', (t) => {
+  const script = Path.join('examples', 'internal-modules.js');
+  const cli = startCLI([script]);
+
+  function onFatal(error) {
+    cli.quit();
+    throw error;
+  }
+
+  return cli.waitForInitialBreak()
+    .then(() => cli.waitForPrompt())
+    .then(() => cli.stepCommand('n'))
+    .then(() => cli.stepCommand('s'))
+    .then(() => {
+      t.notMatch(cli.breakInfo.filename, /^node:/);
+    })
+    .then(() => cli.quit())
+    .then(null, onFatal);
+});


### PR DESCRIPTION
Reference: https://github.com/nodejs/node/issues/11893

This PR is only for node 15 >. (When internal modules are prefixed by `node:`).

## Observations

Settings:

```
node: v15.6.0
DISTRIB_ID=LinuxMint
DISTRIB_RELEASE=20
DISTRIB_CODENAME=ulyana
DISTRIB_DESCRIPTION="Linux Mint 20 Ulyana"
NAME="Linux Mint"
VERSION="20 (Ulyana)"
```

Application example:

```js
'use strict';

const fs = require('fs');

fs.readFile(__filename, function () {});
```

Without this change:

```sh
node inspect example.js
debug> n
debug> s
break in node:fs:322
       320
       321 function readFile(path, options, callback) {
      >322   callback = maybeCallback(callback || options);
       323   options = getOptions(options, { flag: 'r' });
       324   if (!ReadFileContext)
```

On change:

```sh
node inspect example.js
debug> n
debug> s
break in node:internal/validators:218
       216
       217 const validateCallback = hideStackFrames((callback) => {
      >218   if (typeof callback !== 'function')
       219     throw new ERR_INVALID_CALLBACK(callback);
       220 });
```

---

Not sure if it's expected a `break` inside `node:internal/*` when the pattern `^node:` is passed to the blackbox script patterns, may it can be a bug inside pattern matching?

cc: @nodejs/diagnostics 